### PR TITLE
[FIX] Change to myst-nb in requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,6 @@ cartopy
 nbsphinx
 nbconvert
 pypandoc
-myst_parser
+myst-nb
 sphinx-rtd-theme
 sphinx


### PR DESCRIPTION
Changed `myst_parser` to `myst-nb` in `requirements-dev.txt` for building the docs with GitHub Actions.