### PR TITLE
[FIX] pyproject.toml change package "load_data" -> "WBTSdata"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ urls.repository = "https://github.com/ifmeo-hamburg/WBTSdata"
 
 [tool.setuptools]
 packages = [
-  "load_data",
+  "WBTSdata",
 ]
 include-package-data = true
 


### PR DESCRIPTION
The `pyproject.toml` file still referenced package name `load_data` which broke the local install of WBTSdata.